### PR TITLE
Add container weight tweak for Rustic Storage Trunk

### DIFF
--- a/Source/Properties/Settings.cs
+++ b/Source/Properties/Settings.cs
@@ -500,6 +500,11 @@ internal class Settings : JsonModSettings
     [Slider(0f, 500f, 501, NumberFormat = "{0:0.##} KG")]
     public float ContainerCarTrunkCapacity = 40;
 
+    [Name("Trunk (Rustic Storage)")]
+    [Description("Adjust how much weight the Rustic Storage Trunk can hold. Default is 35 KG.")]
+    [Slider(0f, 500f, 501, NumberFormat = "{0:0.##} KG")]
+    public float ContainerRusticStorageTrunkCapacity = 35;
+
     [Name("Trunk (Wooden Box)")]
     [Description("Adjust how much weight Trunk (Wooden Box) can hold. Default is 40 KG.")]
     [Slider(0f, 500f, 501, NumberFormat = "{0:0.##} KG")]

--- a/Source/Tweaks/Container.cs
+++ b/Source/Tweaks/Container.cs
@@ -122,6 +122,12 @@ internal static class Container
                     __instance.m_Capacity = ItemWeight.FromKilograms(Settings.Instance.ContainerTrunkCapacity);
                 }
 
+                // Trunk (Rustic Storage)
+                else if (__instance.name.Contains("CONTAINER_Rustic_Storage_Trunk"))
+                {
+                    __instance.m_Capacity = ItemWeight.FromKilograms(Settings.Instance.ContainerRusticStorageTrunkCapacity);
+                }
+
                 // Lock Box
                 else if (__instance.name.Contains("CONTAINER_LockBoxB"))
                 {


### PR DESCRIPTION
This adds a container weight option for [Rustic Storage Trunk](https://thelongdark.fandom.com/wiki/Rustic_Storage_Trunk).

Confirmed working in-game:
>  <img width="752" height="272" alt="image" src="https://github.com/user-attachments/assets/2b228d17-24bd-4bfc-9dd8-ea5480d34881" />

